### PR TITLE
Criação e Documentação do docker-compose.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Este template foi criado a partir das especificações disponíveis em https://w
 
 ## Elementos implementados
 Novidades:
+* ✨docker-compose: Agora você pode levantar um container docker com joomla rodando, dispensando os passos de instalção manual. Veja mais detalhes em [Docker: Configuração do Joomla com Docker](#docker-configuração-do-joomla-com-docker).
 * ✨Articles Newsflash: Agora o módulo de últimas notícias tem o cabeçalho baseado na categoria tornando dinâmica a criação do módulo. 
 
 
@@ -136,6 +137,43 @@ http://agsp.eb.mil.br
 
 *Certifique-se de substituir "/caminho/para/a/pasta" pelo caminho correto onde você extraiu os arquivos do projeto.*
 
+## Docker: Configuração do Joomla com Docker 
+
+### Requisitos
+
+- [Docker Engine](https://docs.docker.com/engine/install/) ou [Docker Desktop](https://docs.docker.com/desktop/)
+- [Docker Compose](https://docs.docker.com/compose/install/)
+
+### Configuração
+
+1. **Baixe o arquivo Docker Compose**  
+   O arquivo `docker-compose.yaml` está disponível no repositório oficial do [Docker Hub Joomla](https://hub.docker.com/_/joomla). 
+
+2. **Edite o arquivo `docker-compose.yaml`**  
+   Abra o arquivo `docker-compose.yaml` e personalize as credenciais do banco de dados e do Joomla conforme necessário. Certifique-se de ajustar os seguintes parâmetros:
+   
+   - Banco de Dados:
+     ```yaml
+     MYSQL_DATABASE: seu_nome_banco
+     MYSQL_USER: seu_usuario
+     MYSQL_PASSWORD: sua_senha
+     MYSQL_ROOT_PASSWORD: sua_senha_root
+     ```
+   - Joomla:
+     ```yaml
+     JOOMLA_DB_HOST: nome_do_servico_db
+     JOOMLA_DB_NAME: seu_nome_banco
+     JOOMLA_DB_USER: seu_usuario
+     JOOMLA_DB_PASSWORD: sua_senha
+     ```
+
+3. **Execute o Docker Compose**  
+   No diretório onde o arquivo `docker-compose.yaml` está localizado, execute o comando a seguir para iniciar os containers:
+   ```bash
+   docker-compose up -d
+   ```
+4 .**Acesse o Joomla**
+Se estiver utilizando as portas padrão configuradas no docker-compose.yaml, o Joomla estará disponível em http://localhost:8080. Caso contrário, substitua localhost pelo seu endereço IP ou nome de domínio.
 
 ## Contribuições
 Este espaço está aberto a contribuições da comunidade. Sinta-se livre para enviar _pull requests_ ou relatar falhas ou sugestões.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,41 @@
+services:
+
+  joomla:
+    image: joomla
+    restart: always
+    ports:
+      - 8080:80
+    environment:
+      JOOMLA_DB_HOST: db
+      JOOMLA_DB_USER: joomla
+      JOOMLA_DB_PASSWORD: examplepass
+      JOOMLA_DB_NAME: joomla_db
+      JOOMLA_SITE_NAME: Joomla
+      JOOMLA_ADMIN_USER: Joomla Hero
+      JOOMLA_ADMIN_USERNAME: joomla
+      JOOMLA_ADMIN_PASSWORD: joomla@secured
+      JOOMLA_ADMIN_EMAIL: joomla@example.com
+    volumes:
+      - joomla_data:/var/www/html
+    networks:
+      - joomla_network
+
+  db:
+    image: mysql:8.0
+    restart: always
+    environment:
+      MYSQL_DATABASE: joomla_db
+      MYSQL_USER: joomla
+      MYSQL_PASSWORD: examplepass
+      MYSQL_RANDOM_ROOT_PASSWORD: '1'
+    volumes:
+      - db_data:/var/lib/mysql
+    networks:
+      - joomla_network
+
+volumes:
+  joomla_data:
+  db_data:
+
+networks:
+  joomla_network:


### PR DESCRIPTION
### Descrição

Foi implementado um `docker-compose` para simplificar o processo de teste e implantação do Joomla. Com essa adição, agora é possível levantar um container com o Joomla de forma rápida e eficiente, eliminando a necessidade de realizar a instalação manual.

### Próximos Passos

Ainda restam as seguintes tarefas a serem concluídas:
- Criação do `Dockerfile` para personalização da imagem.
- Publicação da imagem no Docker Hub ja com o template do gov para facilitar o acesso e a replicação do ambiente.
