### PR TITLE
fix: Removendo COPY

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -6,9 +6,6 @@ RUN apt-get update && \
     bash \
     curl
 
-# Copiar o diretório de ids-joomla-eb para dentro do container
-COPY ids-joomla-eb/ /var/www/html/tmp
-
 # Criar um arquivo customizado de configuração do PHP para permitir uploads de até 20 MB
 RUN echo "upload_max_filesize = 20M\npost_max_size = 20M" > /usr/local/etc/php/conf.d/custom-php.ini
 


### PR DESCRIPTION
Removi o COPY que fazia a copia da pasta ids-joomla-eb para dentro do container pois estava dando erro, considerando que ao fazer git clone -> docker compose up causa erro na hora de importar o diretório

Sem ele o usuario pode levantar o ambiente base do joomla e fazer as instalações normalmente  como demostrado no curso arrastando e soltando na aba de extensões 